### PR TITLE
Create design document even if database exists.

### DIFF
--- a/lib/connect-couchdb.js
+++ b/lib/connect-couchdb.js
@@ -37,6 +37,16 @@ module.exports = function(connect) {
 
     ConnectCouchDB.prototype.__proto__ = Store.prototype;
 
+    function _put_design_docs(self, revs_limit, cb) {
+        self.db.putDesignDocs([__dirname + '/connect-session.json'], function(err) {
+            _check_error(err);
+            self.db.putOpt('_revs_limit', revs_limit, function(err) {
+                _check_error(err);
+                cb && cb();
+            }.bind(self));
+        }.bind(self));
+    }
+
     ConnectCouchDB.prototype.setup = function(opts, fn) {
         opts = opts || {};
         opts.revs_limit = opts.revs_limit || '1';
@@ -46,18 +56,12 @@ module.exports = function(connect) {
         this.db.get('', function(err, doc) {
             // Database already exists.
             if (!err) {
-                fn && fn();
+                _put_design_docs(this, opts.revs_limit, fn);
             // Database does not exist.
             } else if (err.statusCode === 404) {
                 this.db.dbPut(function(err) {
                     _check_error(err);
-                    this.db.putDesignDocs([__dirname + '/connect-session.json'], function(err) {
-                        _check_error(err);
-                        this.db.putOpt('_revs_limit', opts.revs_limit, function(err) {
-                            _check_error(err);
-                            fn && fn();
-                        }.bind(this));
-                    }.bind(this));
+                    _put_design_docs(this, opts.revs_limit, fn);
                 }.bind(this));
             // Non-404 error occurred.
             } else {


### PR DESCRIPTION
Hi, 

I've got the situation where I need to create the session database myself, rather than allowing connect-couchdb to create it. In this case I would still like connect-couchdb to create the design document though. Here is a small change that does this at connect-couchdb setup time.

Thanks,
Dan.
