### PR TITLE
Periodic reaping of expired sessions can cause the application to be unresponsive

### DIFF
--- a/lib/connect-couchdb.js
+++ b/lib/connect-couchdb.js
@@ -23,17 +23,19 @@ module.exports = function(connect) {
             setInterval(this.reap.bind(this), this.reapInterval);
             setInterval(this.compact.bind(this), this.compactInterval);
         }
-        if (!opts.name) throw "You must define a database";
+        if (!opts.name) {
+            throw "You must define a database";
+        }
         this.db = new Couch(opts);
-    };
+    }
 
     function _check_error(err) {
-        if (err != null) {
+        if (err !== null) {
             console.log("connect-couchdb error:");
             console.log(err);
             console.log(new Error().stack);
         }
-    };
+    }
 
     function _uri_encode(id) {
         // We first decode it to escape any current URI encoding.
@@ -129,16 +131,24 @@ module.exports = function(connect) {
         }.bind(this));
     };
 
+    function destroy(docs, fn) {
+        var self = this;
+        function destroyDocAt(index) {
+            if (index === docs.length) {
+                return fn && fn();
+            } else {
+                self.destroy(docs[index].value._id, function() {
+                    destroyDocAt(index+1);
+                });
+            }
+        }
+        destroyDocAt(0);   
+    }
+
     ConnectCouchDB.prototype.clear = function (fn) {
         this.db.view('_design/connect-sessions/_view/expires', {}, function (err, docs) {
             if (err) return fn && fn(err);
-            var remaining = docs.rows.length;
-            docs.rows.forEach(function (doc) {
-                this.destroy(doc.value._id, function() {
-                    remaining--;
-                    if (!remaining) return fn && fn();
-                });
-            }.bind(this));
+            destroy.call(this, docs.rows, fn);
         }.bind(this));
     };
 
@@ -147,13 +157,7 @@ module.exports = function(connect) {
         var options = { endkey: '[' + now + ',{}]' };
         this.db.view('_design/connect-sessions/_view/expires', options, function (err, docs) {
             if (err) return fn && fn(err);
-            var remaining = docs.rows.length;
-            docs.rows.forEach(function (doc) {
-                this.destroy(doc.value._id, function() {
-                    remaining--;
-                    if (!remaining) return fn && fn();
-                });
-            }.bind(this));
+            destroy.call(this, docs.rows, fn);
         }.bind(this));
     };
 


### PR DESCRIPTION
If there are many sessions to be reaped, then the current implementation of the reap/clear methods can cause the application to be unresponsive. The reason for this is because the reap/clear methods flood couchdb with GET/DELETE requests: all sessions to be reaped are deleted in parallel. I think this then causes issues with the HTTP agent socket limit of 5. 

The modification that I have implemented does serial deletion of sessions to be reaped.
