### PR TITLE
Store reference to intervals and add method for clearing intervals.

### DIFF
--- a/lib/connect-couchdb.js
+++ b/lib/connect-couchdb.js
@@ -1,7 +1,5 @@
 var Couch = require('./couch');
 
-var env = process.env.NODE_ENV;
-
 module.exports = function(connect) {
     var Store = connect.session.Store;
 

--- a/lib/connect-couchdb.js
+++ b/lib/connect-couchdb.js
@@ -19,12 +19,11 @@ module.exports = function(connect) {
 
         // Even when _revs_limit is set to 1, old revisions take up space,
         // therefore, compact the database every once in awhile.
-        if (env !== 'test') {
-            setInterval(this.reap.bind(this), this.reapInterval);
-            if (this.compactInterval !== -1) {
-                setInterval(this.compact.bind(this), this.compactInterval);
-            }
-        }
+        if (this.reapInterval > 0)
+            this._reap = setInterval(this.reap.bind(this), this.reapInterval);
+        if (this.compactInterval > 0)
+            this._compact = setInterval(this.compact.bind(this), this.compactInterval);
+
         if (!opts.name) {
             throw "You must define a database";
         }
@@ -178,6 +177,11 @@ module.exports = function(connect) {
     ConnectCouchDB.prototype.compact = function () {
         var obj = {endpoint: '_compact', doc: {}};
         this.db.post(obj, function(err, res) {});
+    };
+
+    ConnectCouchDB.prototype.clearInterval = function () {
+        if (this._reap) clearInterval(this._reap);
+        if (this._compact) clearInterval(this._compact);
     };
 
     return ConnectCouchDB;

--- a/test/test.store.js
+++ b/test/test.store.js
@@ -46,6 +46,7 @@ module.exports = {
                       store.length(function(err, len){
                         assert.equal(0, len, '#set() null');
                         store.db.dbDel();
+                        store.clearInterval();
                       });
                     });
                   });
@@ -77,6 +78,7 @@ module.exports = {
             store.length(function(err, len) {
               assert.equal(2, len, '#length() after reap');
               store.db.dbDel();
+              store.clearInterval();
             });
           }, 1000);
         });


### PR DESCRIPTION
This branch removes the `env === 'test'` hack for skipping `setInterval` in the constructor and instead gives API users two ways to avoid intervals:
1. Set `opts.reapInterval` and `opts.compactInterval` to <= 0 OR
2. Call `clearInterval()` manually.

I've updated the tests to use this method. The commands in `tools` could be updated as well to clear the intervals and quit gracefully rather than forcefully calling `process.exit(0)`. 
