### PR TITLE
Don't update unchanged session so often - performance issue

### DIFF
--- a/lib/connect-couchdb.js
+++ b/lib/connect-couchdb.js
@@ -128,7 +128,7 @@ module.exports = function(connect) {
                 if (doc.sess.lastAccess) doc.sess.lastAccess = null;
                 if (doc.sess.cookie.originalMaxAge) doc.sess.cookie.originalMaxAge = null;
                 if (doc.sess.cookie._expires) doc.sess.cookie._expires = null;
-                // If session data changed, put new session
+                // Compare new session to current session, save if different.
                 if (JSON.stringify(doc.sess) !== JSON.stringify(sess)) {
                     console.log('session changed');
                     if (_lastAccess)  sess.lastAccess = _lastAccess; 
@@ -138,7 +138,7 @@ module.exports = function(connect) {
                     doc.sess = sess;
                     this.db.put(doc, fn);
                 } else {
-                    // Otherwise, only put if > 1s has elaspsed since last put
+                    // Otherwise, only save if > 1s has elaspsed since last save.
                     if (!locks[sid] || expires > locks[sid] + 1000) {
                         console.log('hit time');
                         locks[sid] = expires;

--- a/lib/connect-couchdb.js
+++ b/lib/connect-couchdb.js
@@ -99,6 +99,9 @@ module.exports = function(connect) {
         }.bind(this));
     };
 
+    // Cache last session update for comparison below.
+    var locks = {};
+
     ConnectCouchDB.prototype.set = function (sid, sess, fn) {
         sid = _uri_encode(sid);
         fn = fn || function () {};
@@ -115,9 +118,40 @@ module.exports = function(connect) {
                 };
                 this.db.put(doc, fn);
             } else {
-                doc.expires = expires;
-                doc.sess = sess;
-                this.db.put(doc, fn);
+                // Temporarily remove properties for session comparison
+                var _lastAccess = sess.lastAccess;
+                var _expires = sess.cookie._expires;
+                var _originalMaxAge = sess.cookie.originalMaxAge; 
+                if (sess.lastAccess) sess.lastAccess = null;
+                if (sess.cookie._expires) sess.cookie._expires = null;
+                if (sess.cookie.originalMaxAge) sess.cookie.originalMaxAge = null;
+                if (doc.sess.lastAccess) doc.sess.lastAccess = null;
+                if (doc.sess.cookie.originalMaxAge) doc.sess.cookie.originalMaxAge = null;
+                if (doc.sess.cookie._expires) doc.sess.cookie._expires = null;
+                // If session data changed, put new session
+                if (JSON.stringify(doc.sess) !== JSON.stringify(sess)) {
+                    console.log('session changed');
+                    if (_lastAccess)  sess.lastAccess = _lastAccess; 
+                    if (_expires) sess.cookie._expires = _expires;
+                    if (_originalMaxAge) sess.cookie.originalMaxAge = _originalMaxAge;
+                    doc.expires = expires;
+                    doc.sess = sess;
+                    this.db.put(doc, fn);
+                } else {
+                    // Otherwise, only put if > 1s has elaspsed since last put
+                    if (!locks[sid] || expires > locks[sid] + 1000) {
+                        console.log('hit time');
+                        locks[sid] = expires;
+                        if (_lastAccess) sess.lastAccess = _lastAccess; 
+                        if (_expires) sess.cookie._expires = _expires;
+                        if (_originalMaxAge) sess.cookie.originalMaxAge = _originalMaxAge;
+                        doc.expires = expires;
+                        doc.sess = sess;
+                        this.db.put(doc, fn);
+                    } else {
+                        return fn();
+                    }
+                }
             }
         }.bind(this));
     };

--- a/lib/connect-couchdb.js
+++ b/lib/connect-couchdb.js
@@ -125,15 +125,16 @@ module.exports = function(connect) {
                     sess.cookie._expires = null;
                 }
                 if (doc.sess.cookie.expires) {
-                    var _expiresDoc = doc.sess.cookie.expires;
                     doc.sess.cookie.expires = null;
                 }
                 sess.lastAccess = null;
                 sess.cookie.originalMaxAge = null;
                 doc.sess.lastAccess = null;
                 doc.sess.cookie.originalMaxAge = null;
-                // Compare new session to current session, save if different.
-                if (JSON.stringify(doc.sess) !== JSON.stringify(sess)) {
+                // Compare new session to current session, save if different
+                // or setThrottle elapses
+                if (JSON.stringify(doc.sess) !== JSON.stringify(sess)
+                    || accessGap > this.setThrottle) {
                     sess.lastAccess = _lastAccess;
                     if (_expires) sess.cookie._expires = _expires;
                     sess.cookie.originalMaxAge = _originalMaxAge;
@@ -141,17 +142,7 @@ module.exports = function(connect) {
                     doc.sess = sess;
                     this.db.put(doc, fn);
                 } else {
-                    // Otherwise, only save if > 1s has elaspsed since last save.
-                    if (accessGap > this.setThrottle) {
-                        sess.lastAccess = _lastAccess;
-                        if (_expires) sess.cookie._expires = _expires;
-                        sess.cookie.originalMaxAge = _originalMaxAge;
-                        doc.expires = expires;
-                        doc.sess = sess;
-                        this.db.put(doc, fn);
-                    } else {
-                        return fn();
-                    }
+                    return fn();
                 }
             }
         }.bind(this));

--- a/lib/connect-couchdb.js
+++ b/lib/connect-couchdb.js
@@ -143,7 +143,7 @@ module.exports = function(connect) {
                     this.db.put(doc, fn);
                 } else {
                     // Otherwise, only save if > 1s has elaspsed since last save.
-                    if (!locks[sid] || expires > locks[sid] + 1000) {
+                    if (!locks[sid] || expires > locks[sid] + 60000) {
                         locks[sid] = expires;
                         sess.lastAccess = _lastAccess;
                         if (_expires) sess.cookie._expires = _expires;

--- a/lib/connect-couchdb.js
+++ b/lib/connect-couchdb.js
@@ -130,7 +130,6 @@ module.exports = function(connect) {
                 if (doc.sess.cookie._expires) doc.sess.cookie._expires = null;
                 // Compare new session to current session, save if different.
                 if (JSON.stringify(doc.sess) !== JSON.stringify(sess)) {
-                    console.log('session changed');
                     if (_lastAccess)  sess.lastAccess = _lastAccess; 
                     if (_expires) sess.cookie._expires = _expires;
                     if (_originalMaxAge) sess.cookie.originalMaxAge = _originalMaxAge;
@@ -140,7 +139,6 @@ module.exports = function(connect) {
                 } else {
                     // Otherwise, only save if > 1s has elaspsed since last save.
                     if (!locks[sid] || expires > locks[sid] + 1000) {
-                        console.log('hit time');
                         locks[sid] = expires;
                         if (_lastAccess) sess.lastAccess = _lastAccess; 
                         if (_expires) sess.cookie._expires = _expires;

--- a/lib/connect-couchdb.js
+++ b/lib/connect-couchdb.js
@@ -14,6 +14,7 @@ module.exports = function(connect) {
         this.db = null;
         this.reapInterval = opts.reapInterval || (10 * 60 * 1000);
         this.compactInterval = opts.compactInterval || (5 * 60 * 1000);
+        this.setThrottle = opts.setThrottle || 60000;
 
         // Even when _revs_limit is set to 1, old revisions take up space,
         // therefore, compact the database every once in awhile.
@@ -99,9 +100,6 @@ module.exports = function(connect) {
         }.bind(this));
     };
 
-    // Cache last session update for comparison below.
-    var locks = {};
-
     ConnectCouchDB.prototype.set = function (sid, sess, fn) {
         sid = _uri_encode(sid);
         fn = fn || function () {};
@@ -118,6 +116,7 @@ module.exports = function(connect) {
                 };
                 this.db.put(doc, fn);
             } else {
+                var accessGap = sess.lastAccess - doc.sess.lastAccess;
                 // Temporarily remove properties for session comparison
                 var _lastAccess = sess.lastAccess;
                 var _originalMaxAge = sess.cookie.originalMaxAge;
@@ -143,8 +142,7 @@ module.exports = function(connect) {
                     this.db.put(doc, fn);
                 } else {
                     // Otherwise, only save if > 1s has elaspsed since last save.
-                    if (!locks[sid] || expires > locks[sid] + 60000) {
-                        locks[sid] = expires;
+                    if (accessGap > this.setThrottle) {
                         sess.lastAccess = _lastAccess;
                         if (_expires) sess.cookie._expires = _expires;
                         sess.cookie.originalMaxAge = _originalMaxAge;

--- a/lib/connect-couchdb.js
+++ b/lib/connect-couchdb.js
@@ -120,19 +120,24 @@ module.exports = function(connect) {
             } else {
                 // Temporarily remove properties for session comparison
                 var _lastAccess = sess.lastAccess;
-                var _expires = sess.cookie._expires;
-                var _originalMaxAge = sess.cookie.originalMaxAge; 
-                if (sess.lastAccess) sess.lastAccess = null;
-                if (sess.cookie._expires) sess.cookie._expires = null;
-                if (sess.cookie.originalMaxAge) sess.cookie.originalMaxAge = null;
-                if (doc.sess.lastAccess) doc.sess.lastAccess = null;
-                if (doc.sess.cookie.originalMaxAge) doc.sess.cookie.originalMaxAge = null;
-                if (doc.sess.cookie._expires) doc.sess.cookie._expires = null;
+                var _originalMaxAge = sess.cookie.originalMaxAge;
+                if (sess.cookie._expires) {
+                    var _expires = sess.cookie._expires;
+                    sess.cookie._expires = null;
+                }
+                if (doc.sess.cookie.expires) {
+                    var _expiresDoc = doc.sess.cookie.expires;
+                    doc.sess.cookie.expires = null;
+                }
+                sess.lastAccess = null;
+                sess.cookie.originalMaxAge = null;
+                doc.sess.lastAccess = null;
+                doc.sess.cookie.originalMaxAge = null;
                 // Compare new session to current session, save if different.
                 if (JSON.stringify(doc.sess) !== JSON.stringify(sess)) {
-                    if (_lastAccess)  sess.lastAccess = _lastAccess; 
+                    sess.lastAccess = _lastAccess;
                     if (_expires) sess.cookie._expires = _expires;
-                    if (_originalMaxAge) sess.cookie.originalMaxAge = _originalMaxAge;
+                    sess.cookie.originalMaxAge = _originalMaxAge;
                     doc.expires = expires;
                     doc.sess = sess;
                     this.db.put(doc, fn);
@@ -140,9 +145,9 @@ module.exports = function(connect) {
                     // Otherwise, only save if > 1s has elaspsed since last save.
                     if (!locks[sid] || expires > locks[sid] + 1000) {
                         locks[sid] = expires;
-                        if (_lastAccess) sess.lastAccess = _lastAccess; 
+                        sess.lastAccess = _lastAccess;
                         if (_expires) sess.cookie._expires = _expires;
-                        if (_originalMaxAge) sess.cookie.originalMaxAge = _originalMaxAge;
+                        sess.cookie.originalMaxAge = _originalMaxAge;
                         doc.expires = expires;
                         doc.sess = sess;
                         this.db.put(doc, fn);

--- a/test/test.store.js
+++ b/test/test.store.js
@@ -89,6 +89,7 @@ module.exports = {
   'throttle': function () {
     var opts = global_opts;
     opts.name = 'connect-couch-throttle';
+    opts.setThrottle = 1000;
     opts.revs_limit = '4';
     var store = new ConnectCouchDB(opts);
     store.setup(opts, function (err, res) {
@@ -132,7 +133,7 @@ module.exports = {
                   store.set('123', { cookie: {
                       maxAge: 20000, originalMaxAge: 19997 },
                     name: 'foo',
-                    lastAccess: 13253760000003
+                    lastAccess: 13253760001003
                   }, function(err, ok){
                     store.get('123', function(err, data){
                       var stop = new Date().getTime();
@@ -150,7 +151,7 @@ module.exports = {
                       store.set('123', { cookie: {
                           maxAge: 20000, _expires: 13253760000003, originalMaxAge: 19997 },
                         name: 'bar',
-                        lastAccess: 13253760000003
+                        lastAccess: 13253760001003
                       }, function(err, ok){
                         store.get('123', function(err, data){
                           assert.equal(false, JSON.stringify(orig) === JSON.stringify(data),
@@ -162,7 +163,7 @@ module.exports = {
                       });
                     });
                   });
-                }, 60000);
+                }, opts.setThrottle + 100);
               });
             });
           });

--- a/test/test.store.js
+++ b/test/test.store.js
@@ -84,5 +84,58 @@ module.exports = {
         });
       });
     });
-  }
+  },
+  // Test session put throttling
+  'throttle': function () {
+    var opts = global_opts;
+    opts.name = 'connect-couch-throttle';
+    opts.revs_limit = '4';
+    var store = new ConnectCouchDB(opts);
+    store.setup(opts, function (err, res) {
+      assert.ok(!err);
+        // First #set()
+        store.set('123', { cookie: { maxAge: 20000 }, name: 'tj'
+        //store.set('123', {
+        //  cookie: {
+        //    maxAge: 2000,
+        //    _expires: 13253760002000,
+        //    originalMaxAge: 2000 
+        //  }, 
+        //  name: 'foo',
+        //  lastAccess: 13253760000000
+        }, function(err, ok){
+          var first = new Date().getTime();
+          store.get('123', function(err, data){
+            console.log(data);
+            // Second #set()
+        store.set('123', { cookie: { maxAge: 20000 }, name: 'tj'
+            //store.set('123', {
+            //  cookie: {
+            //    maxAge: 2000,
+            //    _expires: 13253760004000,
+            //    originalMaxAge: 4000,
+            //  },
+            //  name: 'foo',
+            //  lastAccess: 13253760000001
+            }, function(err, ok){
+              store.get('123', function(err, data){
+                var second = new Date().getTime();
+                // session data not changed. If two sets occurred < 1s, objects should be identical
+                if (second - first < 1000) {
+                  console.log('here');
+                  console.log(data);
+                } else {
+                  console.log('there');
+                  console.log(data);
+                }
+        store.set('123', { cookie: { maxAge: 20000 }, name: 'tj'}, function(err, ok) {
+                store.db.dbDel();
+                store.clearInterval();
+              });
+            });
+          });
+          });
+        });
+      }); 
+  },
 };

--- a/test/test.store.js
+++ b/test/test.store.js
@@ -95,13 +95,13 @@ module.exports = {
       assert.ok(!err);
       // Set new session
       store.set('123', { cookie: {
-          maxAge: 20000, _expires: 13253760000000, originalMaxAge: 20000 },                                                        
+          maxAge: 20000, originalMaxAge: 20000 },                                                        
         name: 'foo',
         lastAccess: 13253760000000
       }, function(err, ok){
           // Set again, now added to locks object in connect-couchdb.js
           store.set('123', { cookie: {
-              maxAge: 20000,  _expires: 13253760000001, originalMaxAge: 19999 },
+              maxAge: 20000,  originalMaxAge: 19999 },
             name: 'foo',
             lastAccess: 13253760000001
           }, function(err, ok){
@@ -110,7 +110,7 @@ module.exports = {
               var orig = data;
               // If we set again now, and less than 1s passes, session should not change              
               store.set('123', { cookie: {
-                  maxAge: 20000, _expires: 13253760000002, originalMaxAge: 19998 },
+                  maxAge: 20000, originalMaxAge: 19998 },
                 name: 'foo',
                 lastAccess: 13253760000002
               }, function(err, ok){
@@ -130,7 +130,7 @@ module.exports = {
                 var start = new Date().getTime();
                 setTimeout(function() { 
                   store.set('123', { cookie: {
-                      maxAge: 20000, _expires: 13253760000003, originalMaxAge: 19997 },
+                      maxAge: 20000, originalMaxAge: 19997 },
                     name: 'foo',
                     lastAccess: 13253760000003
                   }, function(err, ok){
@@ -162,7 +162,7 @@ module.exports = {
                       });
                     });
                   });
-                }, 1100);
+                }, 60000);
               });
             });
           });


### PR DESCRIPTION
This pull request changes how #set() works, whereby if the current session in couch is the same as the session which is about to be `put` to couch, except for timestamps, like lastAccess, expires, and originalMaxAge, and less than 1 minute has passed since the last `put` for this session, then, don't put the session.

Performance wise, the `put` operation is very slow.  I've benchmarked the performance impact on a stack of two servers with couchdb replication running for the session database, and observe the current situation (`put` no matter what) at **25 r/s** compared to `put` only if something significant in the session changed or if > 1m has passed since this session was last put at **105 r/s** which is a major improvement.

The consequence of lots of puts at the second or sub-second level leads to couchdb becoming slow, dealing with the flurry of conflicts and replication.  Once you have maybe 20 or 40 concurrent users surfing around on your web app this becomes a real bottleneck / scalability breaking point.

I've also written a test that tests a session really is not `put` if nothing significant changes in under a minute, and that the session really is changed if significant data changes and is then attempted to be `set`.
