### PR TITLE
Make connect-session.json valid JSON

### DIFF
--- a/lib/connect-session.json
+++ b/lib/connect-session.json
@@ -3,11 +3,7 @@
     "language":"javascript",
     "views": {
         "expires": {
-            "map": "(function (doc) {
-                if (doc.type == 'connect-session' && doc.expires) {
-                    emit([doc.expires, null], {_id: doc._id});
-                }
-            })"
+            "map": "(function (doc) {\n if (doc.type == 'connect-session' && doc.expires) {\n emit([doc.expires, null], {_id: doc._id});\n }\n })"
         }
     }
 }

--- a/test/test.couch.js
+++ b/test/test.couch.js
@@ -1,6 +1,7 @@
 var couch = require('../lib/couch')
   , assert = require('assert')
   , path = require('path')
+  , fs = require('fs')
   , global_opts = {"name": 'connect-couchdb-' + +new Date};
 
 if (path.existsSync('./test/credentials.json')) {
@@ -10,6 +11,17 @@ if (path.existsSync('./test/credentials.json')) {
 }
 
 module.exports = {
+  'connect-session.json is valid json': function() {
+    assert.doesNotThrow(function() {
+      fs.readFile('lib/connect-session.json', function(error, data) {
+        if(error) {
+          throw error;
+        } else {
+          var parsed = JSON.parse(data.toString());
+        }
+      });
+    });
+  },
   'create & delete database': function () {
     var opts = global_opts;
     opts.name = opts.name + '1';


### PR DESCRIPTION
I tested to add the view in couchdb 1.1.2b and 1.2.0 and both complained about invalid JSON. The test ensures that connect-session.json parses without throwing an error.
