### PR TITLE
reduces PUT-requests by fixing a looping condition

### DIFF
--- a/lib/connect-couchdb.js
+++ b/lib/connect-couchdb.js
@@ -133,8 +133,7 @@ module.exports = function(connect) {
                 doc.sess.cookie.originalMaxAge = null;
                 // Compare new session to current session, save if different
                 // or setThrottle elapses
-                if (doc.sess.lastAccess === null
-                    || JSON.stringify(doc.sess) !== JSON.stringify(sess)
+                if (JSON.stringify(doc.sess) !== JSON.stringify(sess)
                     || accessGap > this.setThrottle) {
                     sess.lastAccess = _lastAccess;
                     if (_expires) sess.cookie._expires = _expires;


### PR DESCRIPTION
This fixes a broken looping condition (because doc.sess.lastAccess is explicitly set to null several lines above) that caused issued PUT-requests on every check for cookie lifetime…

The test ensures that the PUT is not done if the cookie is still alive (though the style of the test is debatable… decide if you want it like this…).
