### PR TITLE
Added check for the new yacw 'uri' property

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ## Requirements
 
 - couchdb 1.2.x
-- yacw 0.1.x : the couchdb wrapper. Should be easy to use another one.
+- yacw 0.2.x : the couchdb wrapper. Should be easy to use another one.
 - expresso (only for tests)
 
 ## Installation
@@ -83,3 +83,4 @@ Please invoke the tool to create the design documents when updating to insure yo
 - Konstantin Käfer ([kkaefer](https://github.com/kkaefer))
 - Pau Ramon Revilla ([masylum](https://github.com/masylum))
 - Quentin Raynaud ([even](https://github.com/even))
+- Ivan Erceg ([ierceg](https://github.com/ierceg))

--- a/lib/connect-couchdb.js
+++ b/lib/connect-couchdb.js
@@ -23,7 +23,7 @@ module.exports = function(connect) {
         if (this.compactInterval > 0)
             this._compact = setInterval(this.compact.bind(this), this.compactInterval);
 
-        if (!opts.name) {
+        if (!opts.name && !opts.uri) {
             throw "You must define a database";
         }
         this.db = new Couch(opts);

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
                    "Pau Ramon Revilla (https://github.com/masylum)",
                    "Konstantin Käfer (https://github.com/kkaefer)",
                    "Daniel Bell (https://github.com/danbell)",
-                   "Quentin Raynaud (https://github.com/even)"],
+                   "Quentin Raynaud (https://github.com/even)",
+                   "Ivan Erceg (https://github.com/ierceg"],
   "main": "./index.js",
   "dependencies": {
     "connect": "*",


### PR DESCRIPTION
Now that yacw has a `uri` property in options, it's incorrect to throw an exception when only `name` is not present.
