### PR TITLE
Lock version of connect, it breaks with Connect 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
                    "Ivan Erceg (https://github.com/ierceg"],
   "main": "./index.js",
   "dependencies": {
-    "connect": "*",
+    "connect": "2.17.x",
     "yacw": "0.2.x"
   },
   "devDependencies": {


### PR DESCRIPTION
It appears that Connect 3.x breaks connect-couchdb. Locking versions so the module is still usable.
